### PR TITLE
stack: add initial configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Cabal
 dist/
+# Stack
+.stack-work/
+/stack.yaml.lock

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-15.12
+packages:
+- .


### PR DESCRIPTION
This change adds a stack configuration to help with building.
Cabal is failing with
  [__1] rejecting: base-4.14.0.0/installed-4.1... (conflict: bugzilla =>base>=4.6 && <4.14)