### PR TITLE
demo: fix building error with optional bugFlags

### DIFF
--- a/demo/BugzillaDemo.hs
+++ b/demo/BugzillaDemo.hs
@@ -85,7 +85,7 @@ doRequests user session = do
 
   where
     showNeedinfo Bug {..} = do
-      let flags = filter hasNeedinfoFlag bugFlags
+      let flags = filter hasNeedinfoFlag $ fromMaybe [] bugFlags
       forM_ flags $ \flag ->
         putStrLn $ "[NEEDINFO] " ++ show bugId ++ ": " ++ show bugSummary
                 ++ " (" ++ show (flagSetter flag) ++ " " ++ show (flagCreationDate flag) ++ ")"


### PR DESCRIPTION
This change fixes this building error:
```
    • Couldn't match expected type ‘[Flag]’
                  with actual type ‘Maybe [Flag]’
    • In the second argument of ‘filter’, namely ‘bugFlags’
      In the expression: filter hasNeedinfoFlag bugFlags
      In an equation for ‘flags’: flags = filter hasNeedinfoFlag bugFlags
   |
88 |       let flags = filter hasNeedinfoFlag bugFlags
   |
```