### PR TITLE
Support fully qualified BugzillaServer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # bugzilla-redhat version history
 
+## next
+- BugillaServer can now be fully qualified
+
 ## 0.3.1 (2021-02-07)
 - export sendBzRequest
 


### PR DESCRIPTION
This change enables user to provide a fully qualified BugzillaServer
such as `http://localhost:3000` for integration testing purpose.