### PR TITLE
Remove getBugIncludeFields

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,6 @@
 - BugillaServer can now be fully qualified
 - Add isNotEmpty search expression operator
 - Add searchBugsAll and getBugAll to get all the bug fields
-- Add getBugIncludeFields to select the included fields
 - Change Bug to include ExternalBugs information
 
 ## 0.3.1 (2021-02-07)

--- a/src/Web/Bugzilla/RedHat.hs
+++ b/src/Web/Bugzilla/RedHat.hs
@@ -41,7 +41,6 @@ module Web.Bugzilla.RedHat
 , searchBugsWithLimit'
 , getBug
 , getBugAll
-, getBugIncludeFields
 , getAttachment
 , getAttachments
 , getComments


### PR DESCRIPTION
This change removes the getBugIncludeFields function as it does
not decode properly using the existing Bug data type.