### PR TITLE
Add missing external bug data type exports

### DIFF
--- a/src/Web/Bugzilla/RedHat.hs
+++ b/src/Web/Bugzilla/RedHat.hs
@@ -65,6 +65,8 @@ module Web.Bugzilla.RedHat
 , User (..)
 , Flag (..)
 , Bug (..)
+, ExternalBug (..)
+, ExternalType (..)
 , Attachment (..)
 , Comment (..)
 , History (..)


### PR DESCRIPTION
This change enables user to access the external bugs information.