### PR TITLE
Export Request

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Add isNotEmpty search expression operator
 - Add searchBugsAllWithLimit, searchBugsAll and getBugAll to get all the bug fields
 - Change Bug to include ExternalBugs information
+- Export Request
 
 ## 0.3.1 (2021-02-07)
 - export sendBzRequest

--- a/src/Web/Bugzilla/RedHat.hs
+++ b/src/Web/Bugzilla/RedHat.hs
@@ -53,6 +53,7 @@ module Web.Bugzilla.RedHat
 , sendBzRequest
 , intAsText
 
+, Request
 , BugId
 , AttachmentId
 , CommentId


### PR DESCRIPTION
This change exports the Request data type from http-client
so that users of the library do not need to depends on http-client
to annotate 'sendBzRequest' parameters.