### PR TITLE
executable: allow for containers > 0.7

### DIFF
--- a/bugzilla-redhat.cabal
+++ b/bugzilla-redhat.cabal
@@ -62,7 +62,7 @@ executable bugzilla
   main-is:             BugzillaDemo.hs
   build-depends:       base >=4.6 && <5,
                        bugzilla-redhat,
-                       containers >=0.5 && <0.7,
+                       containers >=0.5 && <0.8,
                        text >=0.11,
                        time >=1.4 && <1.13
   hs-source-dirs:      demo


### PR DESCRIPTION
## description

looks like the `executable` bounds didn't get updated when the others did; I think this is what's stopping it from building with Stackage nightly